### PR TITLE
fix: escape NUL byte in LDAP filter values

### DIFF
--- a/src/main/kotlin/no/foreningenbs/usersapi/ldap/Ldap.kt
+++ b/src/main/kotlin/no/foreningenbs/usersapi/ldap/Ldap.kt
@@ -518,7 +518,7 @@ fun escape(value: String) =
     .replace("(", "\\28")
     .replace(")", "\\29")
     .replace("*", "\\2a")
-    .replace(0x0.toString(), "\\00")
+    .replace("\u0000", "\\00")
 
 fun <E> Enumeration<E>.toList(): List<E> {
   val list = mutableListOf<E>()

--- a/src/test/kotlin/no/foreningenbs/usersapi/ldap/EscapeSpec.kt
+++ b/src/test/kotlin/no/foreningenbs/usersapi/ldap/EscapeSpec.kt
@@ -1,0 +1,27 @@
+package no.foreningenbs.usersapi.ldap
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+class EscapeSpec :
+  DescribeSpec({
+    describe("escape") {
+      it("escapes the five RFC 2254 special characters") {
+        escape("\\") shouldBe "\\5c"
+        escape("(") shouldBe "\\28"
+        escape(")") shouldBe "\\29"
+        escape("*") shouldBe "\\2a"
+        escape("\u0000") shouldBe "\\00"
+      }
+
+      it("does not mangle digits — regression for leo04 bug where '0' was replaced with \\00") {
+        escape("leo04") shouldBe "leo04"
+        escape("0") shouldBe "0"
+      }
+
+      it("leaves benign input untouched") {
+        escape("alice") shouldBe "alice"
+        escape("user@example.com") shouldBe "user@example.com"
+      }
+    }
+  })


### PR DESCRIPTION
## Summary

`escape()` called `replace(0x0.toString(), "\\00")`, but `Int.toString()` returns `"0"` — so every literal digit `0` in usernames/emails was replaced with `\00`. JNDI then DN-decoded `\00` back to a real NUL byte and stored that in LDAP. Username `leo04` was stored as `leo<NUL>4` (`leo\004` in DN form). The email-uniqueness check in `CreateUser` could also spuriously pass for emails containing `0`.

Fix: replace the bogus marker with the actual NUL escape. Added `EscapeSpec` covering all five RFC 2254 special chars plus a regression case for the digit `0`.

## Cleanup needed (manual, post-merge)

- Existing LDAP entries with NUL corruption in `uid` need to be renamed (e.g. `leo<NUL>4` → `leo04`).
- Worth scanning for any other affected users/emails containing the digit `0`.

## Test plan

- [ ] `./gradlew test` passes (couldn't run locally — no JDK in my env)
- [ ] After merge: rename broken LDAP entries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed NUL character escaping in LDAP queries to ensure proper RFC 2254 compliance.

* **Tests**
  * Added comprehensive test suite for LDAP character escaping, validating proper handling of special characters including backslash, parentheses, asterisks, and null characters, plus regression tests for regular input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->